### PR TITLE
Change headless to dotnet 9

### DIFF
--- a/build/headless/Dockerfile.ubuntu
+++ b/build/headless/Dockerfile.ubuntu
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/runtime:8.0 AS base
+FROM mcr.microsoft.com/dotnet/runtime:9.0 AS base
 
 
 RUN apt-get update -y


### PR DESCRIPTION
Modify the headless docker container to use dotnet 9 instead of 8.